### PR TITLE
Add CI to the repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '23 1 * * 0'
+  workflow_dispatch:
+
+jobs:
+  testing:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade .[test]
+
+      - name: Run tests
+        run: tox
+
+  finalise:
+    runs-on: ubuntu-latest
+    needs: [testing]
+    steps:
+      - name: finalise
+        run: echo "All done"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ notebooks/logs/
 venv
 build
 dist
+.tox
+.cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,33 @@ classifiers = [
 license = "MIT"
 license-files = ["LICENSE*"]
 
+[project.optional-dependencies]
+"test" = [
+    "pytest",
+    "tox"
+]
+
 [tool.pytest.ini_options]
 pythonpath = [
   "src",
 ]
+
+[tool.tox]
+requires = ["tox>=4.22"]
+envlist = [
+  "py39",
+  "py310",
+  "py311",
+  "py312",
+  "py313",
+]
+
+[tool.tox.env_run_base]
+change_dir = "{tox_root}/tests"
+allowlist_externals = ["pytest"]
+commands = [
+    ["pytest"],
+]
+
+[tool.tox.env_run_base.setenv]
+PIP_CACHE_DIR = "{tox_root}/.cache/pip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,8 @@ classifiers = [
 ]
 license = "MIT"
 license-files = ["LICENSE*"]
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "src",
+]

--- a/src/derivkit/plotutils/plot_kit.py
+++ b/src/derivkit/plotutils/plot_kit.py
@@ -1,6 +1,7 @@
 import os
 from time import perf_counter
 import time
+from typing import Optional
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -60,9 +61,9 @@ class PlotKit:
         derivative_order: int = 1,
         fit_tolerance=0.05,
         plot_dir: str = "plots",
-        linewidth: float | None = None,
-        colors: dict | None = None,
-        gradient_colors: dict | None = None,
+        linewidth: Optional[float] = None,
+        colors: Optional[dict] = None,
+        gradient_colors: Optional[dict] = None,
         true_derivative_fn=None
     ):
         self.function = function


### PR DESCRIPTION
I have added configuration for [tox](https://tox.wiki/) to the repository. This will help run tests. Users who want to run the tests locally can do the following from the project root:
```
pip install .[test]
tox
```
The first command will install the package with tox and pytest as additional dependencies. Tox will then create environments for a number of Python versions (if avaiable, described in `pyproject.toml`) and run pytest in each of them.

This PR also adds some configuration for Github Actions so that the tests will be run whenever someone pushes something to the repository, merges something with the main branch, or at regularly scheduled intervals.