### PR TITLE
Remove __all__ imports

### DIFF
--- a/src/derivkit/__init__.py
+++ b/src/derivkit/__init__.py
@@ -1,5 +1,6 @@
 from .adaptive_fit import AdaptiveFitDerivative
 from .finite_difference import FiniteDifferenceDerivative
+from .forecast_kit import ForecastKit
 from .kit import DerivativeKit
 from .plotutils.plot_helpers import PlotHelpers
 from .plotutils.plot_style import *
@@ -14,23 +15,3 @@ from .utils import (
     generate_test_function
 )
 
-# from .derivative_tools import DerivativeTools
-# from .expansions import ExpansionTools
-
-from .forecast_kit import ForecastKit
-
-__all__ = [
-    "AdaptiveFitDerivative",
-    "FiniteDifferenceDerivative",
-    "DerivativeKit",
-    "PlotKit",
-    "log_debug_message",
-    "is_finite_and_differentiable",
-    "normalize_derivative",
-    "central_difference_error_estimate",
-    "is_symmetric_grid",
-    "generate_test_function",
-    # "DerivativeTools",
-    # "ExpansionTools"
-    "ForecastKit"
-]


### PR DESCRIPTION
To my knowledge, __all__ is only used to allow users to import submodules from the package into the current namespace. This is considered bad practice, and is probably not something we want to support.

Further reading:
https://docs.python.org/3/tutorial/modules.html#importing-from-a-package