### PR TITLE
Add Github Pages extension to Sphinx conf

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ author = 'Nikolina Šarčević'
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon", 
+    "sphinx.ext.githubpages",
 ]
 
 autoclass_content = "both"


### PR DESCRIPTION
This extension suppresses Github Pages' use of Jekyll. For more information see
https://www.sphinx-doc.org/en/master/usage/extensions/githubpages.html