### PR TITLE
Configure Github Pages to automatically deploy on main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: Deploy Sphinx Documentation
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish_sphinx_docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          pip install -e .[docs]
+
+      - name: Sphinx build
+        run: |
+          sphinx-apidoc -o docs src/derivkit/ --separate
+          sphinx-build docs docs/_build/html
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html
+          force_orphan: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ license-files = ["LICENSE*"]
     "pytest",
     "tox"
 ]
+"docs" = [
+    "sphinx",
+]
 
 [tool.pytest.ini_options]
 pythonpath = [


### PR DESCRIPTION
This will allow Github Pages to automatically deploy Sphinx documentation whenever a contribution is merged with main. It sets up a special `doc` installation which installs [Sphinx](https://www.sphinx-doc.org/en/master/index.html). This will then be used to push documentation to Github Pages.