### PR TITLE
Add ruff as optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,20 @@ license-files = ["LICENSE*"]
     "sphinx",
     "furo",
 ]
+"lint" = [
+    "ruff",
+]
 
 [tool.pytest.ini_options]
 pythonpath = [
   "src",
 ]
+
+[tool.ruff]
+line-length = 79
+
+[tool.ruff.lint]
+extend-select = ["E501"] # enforce `line-too-long` rule
 
 [tool.tox]
 requires = ["tox>=4.22"]


### PR DESCRIPTION
This will allow a user to install [Ruff](https://docs.astral.sh/ruff) as an optional dependency, which allows for code linting and formatting. 