### PR TITLE
Change docstring format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,11 @@ include = ["src/*/*.py", "tests/*.py"]
 # Here we list the styling/formatting rules that Ruff should use.
 # A list of available rules and what each rule does is provided at
 # https://docs.astral.sh/ruff/rules
-select = ["E", "F", "W", "Q", "I"]
+select = ["E", "F", "W", "Q", "I", "D"]
 ignore = ["E203", "E501"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.tox]
 requires = ["tox>=4.22"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ pythonpath = [
 
 [tool.ruff]
 line-length = 79
-include = ["src/*/*.py", "tests/*.py"]
+include = ["src/*/*.py"]
 
 [tool.ruff.lint]
 # Here we list the styling/formatting rules that Ruff should use.

--- a/src/derivkit/__init__.py
+++ b/src/derivkit/__init__.py
@@ -1,3 +1,5 @@
+"""Provides all derivkit methods."""
+
 from .adaptive_fit import AdaptiveFitDerivative
 from .finite_difference import FiniteDifferenceDerivative
 from .forecast_kit import ForecastKit

--- a/src/derivkit/adaptive_fit.py
+++ b/src/derivkit/adaptive_fit.py
@@ -1,3 +1,16 @@
+"""Provides the AdaptiveFitDerivative class.
+
+The user must specify the function to differentiate and the central value
+at which the derivative should be evaluated. More details about available
+options can be found in the documentation of the methods.
+
+Typical usage example:
+
+  derivative = AdaptiveFitDerivative(function_to_differentiate, 1).compute()
+
+derivative is the derivative of function_to_differerentiate at value 1.
+"""
+
 import warnings
 from typing import Optional
 
@@ -8,40 +21,39 @@ from derivkit.finite_difference import FiniteDifferenceDerivative
 
 warnings.simplefilter("once", category=RuntimeWarning)
 
-
 class AdaptiveFitDerivative:
-    """
-    Computes derivatives using an adaptive polynomial fitting approach.
+    """Computes derivatives using an adaptive polynomial fitting approach.
 
-    This method evaluates a function at symmetrically spaced points around a central value,
-    fits a polynomial of specified degree (equal to the derivative order), and computes the
-    derivative by evaluating the derivative of the polynomial at the central point.
+    This method evaluates a function at symmetrically spaced points around
+    a central value, fits a polynomial of specified degree (equal to the
+    derivative order), and computes the derivative by evaluating the derivative
+    of the polynomial at the central point.
 
-    If the polynomial fit fails to meet a specified residual tolerance, the method adaptively
-    removes points with the largest relative residuals (optionally in symmetric pairs) and refits
-    until the tolerance is met or the minimum sample count is reached.
+    If the polynomial fit fails to meet a specified residual tolerance, the
+    method adaptively removes points with the largest relative residuals
+    (optionally in symmetric pairs) and refits until the tolerance is met or the
+    minimum sample count is reached.
 
-    Attributes
-    ----------
-    function : callable
-        The function to be differentiated. Must return scalar or vector output.
-    central_value : float
-        The point at which the derivative is evaluated.
-    diagnostics_data : dict or None
-        The diagnostic data collected during the fitting process, if requested.
-    min_used_points : int
-        Default minimum number of samples required for fitting. This is used to ensure
-        that the polynomial fit has enough data points to be meaningful.
-
-    Methods
-    -------
-    _fallback_derivative()
-        Uses high-order finite differences as a fallback if fit fails.
-    _compute_weights()
-        Provides inverse-distance weights for polynomial fitting.
+    Attributes:
+        function (callable): The function to be differentiated. Must return
+            scalar or vector output.
+        central_value (float): The point at which the derivative is evaluated.
+        diagnostics_data (dict, optional): The diagnostic data collected during
+            the fitting process, if requested. Defaults to `None`.
+        min_used_points (int): The default minimum number of samples required
+            for fitting. This is used to ensure that the polynomial fit has
+            enough data points to be meaningful.
     """
 
     def __init__(self, function, central_value):
+        """Initialises the class based on the function and central value.
+
+        Args:
+            function (callable): The function to be differentiated. Must return
+                scalar or vector output.
+            central_value (float): The point at which the derivative is
+                evaluated.
+        """
         self.function = function
         self.central_value = central_value
         self.diagnostics_data = None
@@ -60,55 +72,57 @@ class AdaptiveFitDerivative:
         floor_accept_multiplier: float = 2.0,
         n_workers: int = 1,
     ):
-        """
-        Estimate the derivative of a function using adaptive polynomial fitting.
+        """Computes class derivative using adaptive polynomial fitting.
 
-        This method evaluates the target function at symmetric points around a central value,
-        fits a polynomial of the specified order, and computes the derivative from that fit.
-        If the fit quality does not meet the specified tolerance, it adaptively prunes the
-        worst residual points and refits. If all attempts fail, it falls back to a finite
-        difference estimate or accepts a fit based on a looser criterion.
+        This method evaluates the target function at symmetric points around
+        a central value, fits a polynomial of the specified order, and computes
+        the derivative from that fit. If the fit quality does not meet the
+        specified tolerance, it adaptively prunes the worst residual points and
+        refits. If all attempts fail, it falls back to a finite difference
+        estimate or accepts a fit based on a looser criterion.
 
-        Parameters
-        ----------
-        derivative_order: int, optional
-            The order of the derivative to compute (default is 1). Must be 1, 2, 3, or 4.
-            Higher orders are not currently supported and will raise a ValueError;
-            the computation will not proceed.
-        min_samples : int, optional
-            Minimum number of total samples to start with. Must be large enough to support the fit
-            and any fallback strategies. Default is 7.
-        fit_tolerance : float, optional
-            Maximum acceptable relative residual for the polynomial fit (default is 0.05, i.e 5%).
-        include_zero : bool, optional
-            Whether to include the central point in the sampling grid (default is True).
-        fallback_mode : str, optional
-            Strategy if the fit fails to meet the tolerance at the minimum sample count.
-            Options are:
+        Args:
+            derivative_order (int, optional): The order of the derivative to
+                compute (default is 1). Must be 1, 2, 3, or 4.
+            min_samples (int, optional): Minimum number of total samples to
+                start with. Must be large enough to support the fit and any
+                fallback strategies. Default is 7.
+            fit_tolerance (float, optional): Maximum acceptable relative
+                residual for the polynomial fit. Default is 0.05, i.e 5%.
+            include_zero (bool, optional): Whether to include the central
+                point in the sampling grid. Default is `True`.
+            fallback_mode: Strategy if the fit fails to meet
+                the tolerance at the minimum sample count. Options are:
 
-                - "finite_difference": always reject and use finite difference fallback.
-                - "poly_at_floor": always accept the polynomial fit at floor regardless of residuals.
-                - "auto": accept the polynomial at floor if:
+                    - `"finite_difference"`: always reject and use finite difference
+                      fallback.
+                    - `"poly_at_floor"`: always accept the polynomial fit at floor
+                      regardless of residuals.
+                    - `"auto"`: accept the polynomial at floor if both of the
+                      following conditions hold:
 
-                    * (max_residual < floor_accept_multiplier × fit_tolerance) AND
-                    * (median_residual < fit_tolerance);
+                        * (max_residual < floor_accept_multiplier × fit_tolerance)
+                        * (median_residual < fit_tolerance);
 
-                  otherwise fall back to finite differences.
+                      otherwise fall back to finite differences.
 
-            Default is "finite_difference".
-        floor_accept_multiplier : float, optional
-            Tolerance multiplier used in "auto" fallback mode. Default is 2.0.
-        diagnostics : bool, optional
-            Whether to return diagnostic information such as residuals, fit values,
-            and pruning status. Default is False.
-        n_workers: int, optional
-            Number of worker to use in multiprocessing. Default is 1 (no multiprocessing).
+                Default is `"finite_difference"`.
+            floor_accept_multiplier: Tolerance multiplier
+                used in "auto" fallback mode. Default is 2.0.
+            diagnostics (bool, optional): Whether to return diagnostic
+                information such as residuals, fit values, and pruning status.
+                Default is `False`.
+            n_workers: Number of worker to use in multiprocessing. Default is 1
+                (no multiprocessing).
 
-        Returns
-        -------
-        np.ndarray or (np.ndarray, dict)
-            The estimated derivative(s). If `diagnostics` is True, returns a tuple with the
-            derivative array and a dictionary of diagnostic data.
+        Returns:
+            :class:`np.ndarray`, (:class:`np.ndarray`, dict): The estimated
+                derivative(s). If `diagnostics` is `True`, returns a tuple
+                with the derivative array and a dictionary of diagnostic data.
+
+        Raises:
+            ValueError: An error occurred attempting to comput derivatives
+                of order higher than 4.
         """
         if derivative_order not in [1, 2, 3, 4]:
             raise ValueError(
@@ -316,31 +330,31 @@ class AdaptiveFitDerivative:
         step_mode="auto",  # "auto" | "relative" | "absolute"
         x_small_threshold=1e-3,
     ):
-        """
-        Returns an array of absolute step sizes to use for adaptive sampling.
+        """Returns an array of absolute step sizes to use for adaptive sampling.
 
-        Parameters:
-            central_value : float or None
-               The central value around which to generate offsets. If None, uses `self.central_value`.
-            base_rel : float
-               Base relative step size as a fraction of the central value. Default is 1%.
-            base_abs : float
-               Base absolute step size for small central values. Default is 1e-6.
-            factor : float
-               Factor by which to increase the step size for each offset. Default is 1.5.
-            num_offsets : int
-               Number of offsets to generate. Default is 10.
-            max_rel : float
-               Maximum relative step size as a fraction of the central value. Default is 5%.
-            max_abs : float
-               Maximum absolute step size. Default is 1e-2.
-            step_mode : str
-               Mode for determining step sizes: "auto", "relative", or "absolute". Defaults to "auto".
-            x_small_threshold : float
-               Threshold below which the central value is considered small. Default is 1e-3.
+        Args:
+            central_value (float_optional): The central value around which to
+                generate offsets. If None, uses `self.central_value`.
+            base_rel (float, optional): Base relative step size as a fraction
+                of the central value. Default is 1%.
+            base_abs (float, optional): Base absolute step size for small
+                central values. Default is 1e-6.
+            factor (float, optional): Factor by which to increase the step
+                size for each offset. Default is 1.5.
+            num_offsets (int, optional): Number of offsets to generate. Default
+                is 10.
+            max_rel (float, optional): Maximum relative step size as a fraction
+                of the central value. Default is 5%.
+            max_abs (float, optional): Maximum absolute step size.
+                Default is 1e-2.
+            step_mode (str, optional): Mode for determining step sizes: "auto",
+                "relative", or "absolute". Defaults to "auto".
+            x_small_threshold (float, optional): Threshold below which the
+                central value is considered small. Default is 1e-3.
 
         Returns:
-            Absolute step sizes (positive only), not including the central 0 step.
+            :class:`np.ndarray`: An array with absolute step sizes (positive
+                only), not including the central 0 step.
         """
         x0 = (
             self.central_value
@@ -375,40 +389,40 @@ class AdaptiveFitDerivative:
         include_zero: bool,
         min_samples: int,
     ):
+        """Construct a symmetric array of sampling offsets around central value.
+
+        The method adaptively builds a grid of offsets by mirroring around the
+        center, ensuring that the number of total points (including optional
+        center) is sufficient for fitting the requested derivative order. It
+        expands the offset range as needed until the required minimum number of
+        points is met, up to a maximum span.
+
+        Args:
+            central_value (float): The central point around which the offsets
+                are generated. This is the point at which the derivative will
+                be evaluated.
+            derivative_order (int): The order of the derivative to be computed.
+                Determines the minimum polynomial degree, which affects the
+                number of required sample points.
+            include_zero: Whether to include the central point (zero
+                offset) in the sampling grid.
+            min_samples: The minimum number of total sampling points to
+                start with before pruning. This interacts with
+                `self.min_used_points` (default = 5), which is the minimum
+                number of points required to perform a polynomial fit, and with
+                the derivative order to determine the final required number of
+                usable samples.
+
+        Returns:
+            (:class:`np.ndarray`, int): A tuple containing
+
+            - an array of symmetric offsets relative to `self.central_value`,
+              optionally including zero. These define where the function will be
+              evaluated.
+            - The minimum number of samples that must be retained during
+              adaptive fitting for the derivative estimate to proceed
+              (i.e. the floor used in pruning logic).
         """
-        Construct a symmetric array of sampling offsets around `central_value` for polynomial fitting.
-
-        The method adaptively builds a grid of offsets by mirroring around the center,
-        ensuring that the number of total points (including optional center) is sufficient
-        for fitting the requested derivative order. It expands the offset range as needed
-        until the required minimum number of points is met, up to a maximum span.
-
-        Parameters
-        ----------
-        central_value : float
-            The central point around which the offsets are generated. This is the point at which
-            the derivative will be evaluated.
-        derivative_order : int
-            The order of the derivative to be computed. Determines the minimum polynomial degree,
-            which affects the number of required sample points.
-        include_zero : bool
-            Whether to include the central point (zero offset) in the sampling grid.
-        min_samples : int
-            The minimum number of total sampling points to start with before pruning.
-            This interacts with `self.min_used_points` (default = 5), which is the
-            minimum number of points required to perform a polynomial fit, and with
-            the derivative order to determine the final required number of usable samples
-
-        Returns
-        -------
-        x_offsets : np.ndarray
-            Array of symmetric offsets relative to `self.central_value`, optionally including zero.
-            These define where the function will be evaluated.
-        required_points : int
-            The minimum number of samples that must be retained during adaptive fitting
-            for the derivative estimate to proceed (i.e. the floor used in pruning logic).
-        """
-
         # Enforce a hard floor of >=5 used points
         if self.min_used_points < 5:
             warnings.warn(
@@ -439,22 +453,16 @@ class AdaptiveFitDerivative:
     def _fit_once(
         self, x_vals: np.ndarray, y_vals: np.ndarray, derivative_order: int
     ):
-        """
-        Perform one normalized weighted polynomial fit on (x_vals, y_vals).
+        """Perform one normalized weighted polynomial fit on (x_vals, y_vals).
 
-        Parameters
-        ----------
-        x_vals : np.ndarray
-            Sample x values used in the fit.
-        y_vals : np.ndarray
-            Corresponding function values.
-        derivative_order : int
-            Order of the derivative to fit.
+        Args:
+            x_vals: Sample x values used in the fit.
+            y_vals: function values corresponsing to `x_vals`.
+            derivative_order: Order of the derivative to fit.
 
-        Returns
-        -------
-        dict
-            Dictionary containing fit result, polynomial object, residuals, and metadata.
+        Returns:
+            dict: Dictionary containing fit result, polynomial object,
+                residuals, and metadata.
         """
         # Normalize coordinates around the center for conditioning
         t_vals = x_vals - self.central_value
@@ -508,45 +516,52 @@ class AdaptiveFitDerivative:
         fallback_mode: str,
         floor_accept_multiplier: float,
     ):
-        """
-        Determine whether to accept a polynomial fit computed at the minimum stencil size ("floor").
+        """Determine whether to accept a polynomial fit.
 
-        This function is called when the adaptive fitting loop has reached its smallest
-        allowable number of sample points (`at_floor=True`) but has not yet met the target
-        residual tolerance. Depending on the fallback strategy and the quality of the residuals,
-        the method decides whether the fit should be accepted anyway or whether to trigger
-        a fallback (e.g., finite difference).
+        The fit is computed at the minimum stencil size ("floor").
 
-        Parameters
-        ----------
-        last_residuals : np.ndarray or None
-            Residuals from the last attempted polynomial fit. If None, acceptance is based only
-            on fallback_mode and at_floor status.
-        at_floor : bool
-            Whether the algorithm has reached the minimum allowed number of sample points.
-        fit_tolerance : float
-            The user-specified threshold for acceptable residuals. Typically a small value like 1e-4.
-        fallback_mode : str
-            Strategy to follow when the fit fails at the floor. Options include:
-            - "poly_at_floor": always accept the fit at floor regardless of residuals
-            - "auto": accept if residuals are close enough to tolerance
-            - "finite_difference": always reject and fall back to finite differences
-        floor_accept_multiplier : float
-            Tolerance multiplier for fallback_mode="auto". Allows leniency for accepting slightly
-            worse-than-tolerance fits if residuals are close. Typically 1.5–2.0.
+        This function is called when the adaptive fitting loop has reached its
+        smallest allowable number of sample points (`at_floor=True`) but has
+        not yet met the target residual tolerance. Depending on the fallback
+        strategy and the quality of the residuals, the method decides whether
+        the fit should be accepted anyway or whether to trigger a fallback
+        (e.g., finite difference).
 
-        Returns
-        -------
-        accept : bool
-            Whether to accept the polynomial fit despite failing to meet tolerance.
-        tag : str
-            Human-readable diagnostic tag describing the decision outcome. One of:
-            - "not_at_floor"
-            - "poly_at_floor"
-            - "auto_accept_at_floor"
-            - "auto_reject"
-            - "auto_no_residuals"
-            - "finite_difference"
+        Args:
+            last_residuals: Residuals from the last attempted polynomial fit.
+                If ``None``, acceptance is based only on fallback_mode and
+                `at_floor` status.
+            at_floor: Whether the algorithm has reached the minimum allowed
+                number of sample points.
+            fit_tolerance: The user-specified threshold for acceptablei
+                residuals. Typically a small value like 1e-4.
+            fallback_mode: Strategy to follow when the fit fails at the floor.
+                Options include:
+
+                  - "poly_at_floor: always accept the fit at floor regardless
+                    of residuals
+                  - "auto": accept if residuals are close enough to tolerance
+                  - "finite_difference": always reject and fall back to finite
+                    differences
+
+            floor_accept_multiplier: Tolerance multiplier for
+                `fallback_mode="auto"`. Allows leniency for accepting slightly
+                worse-than-tolerance fits if residuals are close.
+                Typically 1.5–2.0.
+
+        Returns:
+         (bool, str): a tuple containing
+
+            - A boolean signifying whether the polynomial fit should be accepted
+              despite failing to meet tolerance.
+            - Human-readable diagnostic tag describing the decision outcome.
+              One of:
+              - "not_at_floor"
+              - "poly_at_floor"
+              - "auto_accept_at_floor"
+              - "auto_reject"
+              - "auto_no_residuals"
+              - "finite_difference"
         """
         if not at_floor:
             return False, "not_at_floor"
@@ -572,33 +587,33 @@ class AdaptiveFitDerivative:
         return False, "finite_difference"
 
     def _fallback_derivative(self, derivative_order, n_workers=1):
-        """
-        Compute the derivative using a finite difference method when adaptive fitting fails.
+        """Compute the derivative using a finite difference method.
 
-        This method is only called as a last resort if the adaptive polynomial fitting
-        procedure:
+        Used when adaptive fitting fails.
+
+        This method is only called as a last resort if the adaptive polynomial
+        fitting procedure:
           - Cannot achieve the specified residual tolerance, or
           - Encounters numerical issues such as singular matrix errors.
 
-        In such cases, it delegates the computation to `FiniteDifferenceDerivative`,
-        which uses a high-order finite difference scheme to estimate the derivative
-        at the same central point.
+        In such cases, it delegates the computation to
+        :class:`derivkit.finite_difference.FiniteDifferenceDerivative`,
+        which uses a high-order finite difference scheme to estimate the
+        derivative at the same central point.
 
-        Parameters
-        ----------
-        derivative_order : int
-            The order of the derivative to compute. Must be one of the orders supported
-            by `FiniteDifferenceDerivative` (currently 1–4).
-        n_workers: int, optional
-            Number of worker to use in multiprocessing. Default is 1 (no multiprocessing).
+        Args:
+            derivative_order (int):
+                The order of the derivative to compute. Must be one of the
+                orders supported by :class:`derivkit.finite_difference.FiniteDifferenceDerivative`
+                (currently 1–4).
+            n_workers (int, optional): Number of worker to use in
+                multiprocessing. Default is 1 (no multiprocessing).
 
-        Returns
-        -------
-        np.ndarray
-            The fallback derivative estimate(s) as a 1D array, with one value per
-            output component of the target function.
+        Returns:
+            :class:`np.ndarray`: The fallback derivative estimate(s) as a 1D
+                array, with one value per output component of the target
+                function.
         """
-
         warnings.warn(
             "Falling back to finite difference derivative.", RuntimeWarning
         )
@@ -613,20 +628,16 @@ class AdaptiveFitDerivative:
         return np.atleast_1d(result)
 
     def recommend_fit_tolerance(self, dx=1e-3, verbose=True):
-        """
-        Suggests a fit_tolerance value based on local function variation.
+        """Suggests a fit_tolerance value based on local function variation.
 
-        Parameters
-        ----------
-        dx : float
-            Offset used to probe nearby values.
-        verbose : bool
-            Whether to print out the suggested value.
+        Args:
+            dx (float, optional): Offset used to probe nearby values. Default
+                value is `1e-3`.
+            verbose (bool, optional): Whether to print out the suggested value.
+                Default value is `True`.
 
-        Returns
-        -------
-        float
-            Recommended fit_tolerance.
+        Returns:
+            float: Recommended fit_tolerance.
         """
         try:
             y_plus = np.atleast_1d(self.function(self.central_value + dx))
@@ -655,11 +666,11 @@ class AdaptiveFitDerivative:
             return 0.05
 
     def _compute_weights(self, x_vals):
-        """
-        Compute scale-aware inverse-distance weights centered at ``central_value``.
+        """Compute scale-aware inverse-distance weights around ``central_value``.
 
-        This weighting emphasizes samples closest to the expansion point ``x0 = self.central_value``
-        while remaining numerically stable across *very small* and *very large* parameter scales.
+        This weighting emphasizes samples closest to the expansion point
+        ``x0 = self.central_value`` while remaining numerically stable across
+        *very small* and *very large* parameter scales.
 
         **Formulation**
         ----------------
@@ -669,45 +680,49 @@ class AdaptiveFitDerivative:
         and define the weights
             ``w_i = 1 / (d_i + eps)``.
 
-        - The additive softening ``eps`` prevents a singular weight at the center (where ``d_i = 0``).
-        - Tying ``eps`` to the span ``D`` makes the weighting *scale-invariant*: the relative
-          emphasis near the center is similar whether ``x0`` is ~1e-4 or ~1e4.
+        - The additive softening ``eps`` prevents a singular weight at the
+          center (where ``d_i = 0``).
+        - Tying ``eps`` to the span ``D`` makes the weighting *scale-invariant*:
+          the relative emphasis near the center is similar whether ``x0``
+          is ~1e-4 or ~1e4.
 
         **Intuition**
         --------------
         With ``eps = 1e-3 * D``, the center-to-edge weight ratio is roughly:
             ``w(0) / w(D) ≈ (D + eps) / eps ≈ D / eps ≈ 10^3``.
-        So points near ``x0`` can carry ~1000× more weight than the farthest points—strong,
-        but not overwhelming. You can tune this by changing the 1e-3 factor:
+        So points near ``x0`` can carry ~1000× more weight than the farthest
+        points—strong, but not overwhelming. You can tune this by changing the
+        1e-3 factor:
         - Larger factor (e.g., ``1e-2``) → milder emphasis (~100×).
         - Smaller factor (e.g., ``1e-4``) → sharper emphasis (~10,000×).
 
         **Why not a fixed epsilon?**
         -----------------------------
         A constant (e.g., ``1e-4``) behaves poorly across scales:
-        - If the step span is tiny (<< 1e-4), the constant dominates and flattens the weights
-          (little central emphasis).
-        - If the span is large (>> 1e-4), the center weight becomes excessively dominant.
+        - If the step span is tiny (<< 1e-4), the constant dominates and
+          flattens the weights (little central emphasis).
+        - If the span is large (>> 1e-4), the center weight becomes excessively
+          dominant.
 
-        By scaling ``eps`` with the current span, the weighting profile adapts automatically.
+        By scaling ``eps`` with the current span, the weighting profile adapts
+        automatically.
 
-        Parameters
-        ----------
-        x_vals : np.ndarray
-            Sample locations used in fitting. Shape ``(n_points,)``.
-
-        Returns
-        -------
-        np.ndarray
-            Weights of shape ``(n_points,)``. These are **not normalized**; downstream code
-            (e.g., ``np.polyfit(..., w=weights)``) uses them as relative weights. If a normalized
-            weight vector is required, divide by ``weights.sum()``.
-
-        Notes
+        Notes:
         -----
         - Complexity is O(n).
-        - The absolute floor ``1e-9`` guards degenerate cases (e.g., ``D ≈ 0``) and prevents
-          overflow even if multiple samples coincide with ``x0``.
+        - The absolute floor ``1e-9`` guards degenerate cases (e.g., ``D ≈ 0``)
+          and prevents overflow even if multiple samples coincide with ``x0``.
+
+        Args:
+            x_vals (:class:`np.ndarray`): Sample locations used in fitting.
+                Shape ``(n_points,)``.
+
+        Returns:
+            :class:`np.ndarray`: Weights of shape ``(n_points,)``. These are
+                **not normalized**; downstream code (e.g.,
+                ``np.polyfit(..., w=weights)``) uses them as relative weights.
+                If a normalized weight vector is required, divide by
+                ``weights.sum()``.
         """
         d = np.abs(x_vals - self.central_value)
         eps = max(np.max(d) * 1e-3, 1e-9)  # 0.1% of span with tiny floor
@@ -725,40 +740,39 @@ class AdaptiveFitDerivative:
         keep_center: bool = True,
         keep_symmetric: bool = True,
     ):
-        """
-        Remove points whose relative residual exceeds ``fit_tolerance``, then refit.
+        """Removes points whose relative residual exceeds tolerance.
+
+        The function refits after the residuals have been removed.
 
         Strategy
         --------
-        - Sort points by residual (worst-first) and remove up to ``max_remove`` per call.
-        - Never drop the center sample (closest to ``central_value``) if ``keep_center`` is True.
-        - If ``keep_symmetric`` is True, also remove the mirror of the removed point
-          about ``central_value`` when possible (to keep sampling balanced).
+        - Sort points by residual (worst-first) and remove up to ``max_remove``
+          per call.
+        - Never drop the center sample (closest to ``central_value``) if
+          ``keep_center`` is True.
+        - If ``keep_symmetric`` is True, also remove the mirror of the removed
+          point about ``central_value`` when possible (to keep sampling
+          balanced).
         - Never reduce the number of points below ``required_points``.
 
-        Parameters
-        ----------
-        x_vals, y_vals : np.ndarray
-            Current sample abscissae and ordinates (same length).
-        residuals : np.ndarray
-            Relative residuals for the *current* fit at ``x_vals``.
-        fit_tolerance : float
-            Acceptable residual threshold (e.g., 0.05 for 5%).
-        required_points : int
-            Minimum number of points allowed after pruning.
-        max_remove : int, optional
-            Maximum number of points to remove in this call (default 2).
-        keep_center : bool, optional
-            If True, never remove the point closest to ``central_value``.
-        keep_symmetric : bool, optional
-            If True, attempt to remove a mirror point along with the worst point.
+        Args:
+            x_vals: Current sample abscissae.
+            y_vals: Current sample ordinates (must be the same length as
+                ``x_vals``).
+            residuals: Relative residuals for the *current* fit at ``x_vals``.
+            fit_tolerance : Acceptable residual threshold (e.g., 0.05 for 5%).
+            required_points: Minimum number of points allowed after pruning.
+            max_remove: Maximum number of points to remove in this call (default 2).
+            keep_center: If True, never remove the point closest to
+                ``central_value``. Default is `True`.
+            keep_symmetric: If True, attempt to remove a mirror point along with
+                the worst point.
 
-        Returns
-        -------
-        x_new, y_new : np.ndarray
-            Pruned arrays (may be unchanged).
-        removed_any : bool
-            True if at least one point was removed.
+        Returns:
+            (:class:`np.ndarray`, :class:`np.ndarray`, bool): A tuple containing
+
+                - Pruned arrays x_vals and y_vals (may be unchanged).
+                - A boolean which is `True` if at least one point was removed.
         """
         assert len(x_vals) == len(y_vals) == len(residuals)
 
@@ -814,25 +828,20 @@ class AdaptiveFitDerivative:
     def _store_diagnostics_entry(
         self, x_all, x_used, y_used, y_fit, residuals
     ):
-        """
-        Store diagnostic info for a single component.
+        """Stores diagnostic info for a single component.
 
-        Parameters
-        ----------
-        x_all : np.ndarray
-            All x values used in the fit.
-        x_used : np.ndarray or None
-            x values actually used in the fit (None if no points were used).
-        y_used : np.ndarray or None
-            y values corresponding to `x_used` (None if no points were used).
-        y_fit : np.ndarray or None
-            Fitted y values corresponding to `x_used` (None if no points were used).
-        residuals : np.ndarray or None
-            Residuals of the fit corresponding to `y_used` (None if no points were used).
+        Updates the diagnostics_data dictionary with the new entry.
 
-        Returns
-        -------
-            Updates the diagnostics_data dictionary with the new entry.
+        Args:
+            x_all (:class:`np.ndarray`): All x values used in the fit.
+            x_used (:class:`np.ndarray`): x values actually used in the fit
+                (``None`` if no points were used).
+            y_used (:class:`np.ndarray`): y values corresponding to ``x_used``
+                (None if no points were used).
+            y_fit (:class:`np.ndarray`): Fitted y values corresponding to
+                `x_used` (None if no points were used).
+            residuals (:class:`np.ndarray`): Residuals of the fit corresponding
+                to `y_used` (None if no points were used).
         """
         if self.diagnostics_data is None:
             return

--- a/src/derivkit/kit.py
+++ b/src/derivkit/kit.py
@@ -1,3 +1,19 @@
+"""Provides the DerivativeKit class.
+
+The class is essentially a wrapper for :class:`AdaptiveFitDerivative` and
+:class:`FiniteDifferenceDerivative`. The user must specify the function to
+differentiate and the central value at which the derivative should be
+evaluated. More details about available options can be found in the
+documentation of the methods.
+
+Typical usage example:
+
+  derivative = DerivativeKit(function_to_differentiate, 1)
+  adaptive = derivative.adaptive.compute()
+
+derivative is the derivative of function_to_differerentiate at value 1.
+"""
+
 from typing import Callable
 
 from derivkit.adaptive_fit import AdaptiveFitDerivative
@@ -5,22 +21,13 @@ from derivkit.finite_difference import FiniteDifferenceDerivative
 
 
 class DerivativeKit:
-    """
-    Provides unified access to both adaptive and finite difference derivative calculators.
+    """Provides access to adaptive and finite difference derivative calculators.
 
-    Attributes
-    ----------
-    adaptive : AdaptiveFitDerivative
-        Adaptive polynomial fit-based derivative method.
-    finite : FiniteDifferenceDerivative
-        High-order finite difference stencil-based method.
-
-    Parameters
-    ----------
-    function : callable
-        The scalar or vector-valued function to differentiate.
-    central_value : float
-        The point at which the derivative is evaluated.
+    Attributes:
+        adaptive (:class:``AdaptiveFitDerivative``): Adaptive polynomial
+            fit-based derivative method.
+        finite (:class:`` FiniteDifferenceDerivative``): High-order finite
+            difference stencil-based method.
     """
 
     def __init__(
@@ -28,24 +35,26 @@ class DerivativeKit:
         function: Callable[[float], float],
         central_value: float,
     ):
+        """Initialises the class based on function and central value.
+
+        Args:
+            function: The scalar or vector-valued function to differentiate.
+            central_value: The point at which the derivative is evaluated.
+        """
         self.adaptive = AdaptiveFitDerivative(function, central_value)
         self.finite = FiniteDifferenceDerivative(function, central_value)
 
     def get_used_points(self, derivative_order: int = 1, n_workers=1):
-        """
-        Returns x and y points used in the adaptive fit (for component 0).
+        """Returns x and y points used in the adaptive fit (for component 0).
 
-        Parameters
-        ----------
-        derivative_order : int, optional
-            Order of the derivative to compute diagnostics for (default is 1).
-        n_workers: int, optional
-            Number of worker to use in multiprocessing. Default is 1 (no multiprocessing).
+        Args:
+            derivative_order: Order of the derivative to compute diagnostics
+                for (default is 1).
+            n_workers (int, optional): Number of worker to use in
+                multiprocessing. Default is 1 (no multiprocessing).
 
-        Returns
-        -------
-        tuple of np.ndarray
-            (x_all, y_all, x_used, y_used, used_mask)
+        Returns:
+            A tuple of :class:`np.ndarray`.
         """
         _, diagnostics = self.adaptive.compute(
             derivative_order=derivative_order,

--- a/src/derivkit/plotutils/plot_helpers.py
+++ b/src/derivkit/plotutils/plot_helpers.py
@@ -1,3 +1,5 @@
+"""Provides a class of assorted plotting helper functions."""
+
 import math
 import os
 
@@ -9,8 +11,7 @@ from derivkit.kit import DerivativeKit
 
 
 class PlotHelpers:
-    """
-    Utility class to support plotting and evaluation of numerical derivatives under noise.
+    """Utility class to support plotting and evaluation of numerical derivatives under noise.
 
     Provides helper functions for:
     - Creating noisy function versions
@@ -18,19 +19,6 @@ class PlotHelpers:
     - Comparing different derivative methods
     - Computing or approximating reference derivatives
     - Saving consistent figures to disk
-
-    Parameters
-    ----------
-    function : callable
-        Original function to be differentiated.
-    central_value : float
-        Central evaluation point.
-    fit_tolerance : float, optional
-        Tolerance used for adaptive fitting (default is 0.05).
-    true_derivative_fn : callable, optional
-        Ground-truth derivative function, if available.
-    plot_dir : str, optional
-        Directory to save output plots (default is "plots").
     """
 
     def __init__(
@@ -41,6 +29,20 @@ class PlotHelpers:
         true_derivative_fn=None,
         plot_dir: str = "plots",
     ):
+        """Initialises the class.
+
+        Args:
+            function : callable
+                Original function to be differentiated.
+            central_value : float
+                Central evaluation point.
+            fit_tolerance : float, optional
+                Tolerance used for adaptive fitting (default is 0.05).
+            true_derivative_fn : callable, optional
+                Ground-truth derivative function, if available.
+            plot_dir : str, optional
+                Directory to save output plots (default is "plots").
+        """
         self.function = function
         self.central_value = central_value
         self.plot_dir = plot_dir
@@ -54,22 +56,19 @@ class PlotHelpers:
     def get_noisy_derivatives(
         self, derivative_order, noise_std=0.01, trials=100
     ):
-        """
-        Compute derivative estimates across multiple noisy trials using finite, adaptive, and Numdifftools methods.
+        """Compute derivative estimates across multiple noisy trials using finite, adaptive, and Numdifftools methods.
 
-        Parameters
-        ----------
-        derivative_order : int
-            The order of the derivative to compute.
-        noise_std : float
-            Standard deviation of the noise to add to the function.
-        trials : int
-            Number of noisy trials to run.
+        Args:
+            derivative_order : int
+                The order of the derivative to compute.
+            noise_std : float
+                Standard deviation of the noise to add to the function.
+            trials : int
+                Number of noisy trials to run.
 
-        Returns
-        -------
-        tuple of lists
-            (finite_differences, adaptive_fits, numdifftools_estimates)
+        Returns:
+            tuple of lists
+                (finite_differences, adaptive_fits, numdifftools_estimates)
         """
         rng = np.random.default_rng(self.seed)
         finite_vals, adaptive_vals, nd_vals = [], [], []
@@ -100,24 +99,21 @@ class PlotHelpers:
     def run_derivative_trials_with_noise(
         self, method="finite", order=1, noise_std=0.01, trials=100
     ):
-        """
-        Run repeated derivative estimation trials with a specified method and added noise.
+        """Run repeated derivative estimation trials with a specified method and added noise.
 
-        Parameters
-        ----------
-        method : str
-            One of {"finite", "adaptive", "numdifftools"}.
-        order : int
-            Derivative order to compute.
-        noise_std : float
-            Standard deviation of the noise.
-        trials : int
-            Number of trials to run.
+        Args:
+            method : str
+                One of {"finite", "adaptive", "numdifftools"}.
+            order : int
+                Derivative order to compute.
+            noise_std : float
+                Standard deviation of the noise.
+            trials : int
+                Number of trials to run.
 
-        Returns
-        -------
-        list
-            Derivative estimates for each trial.
+        Returns:
+            list
+                Derivative estimates for each trial.
         """
         results = []
         for i in range(trials):
@@ -173,28 +169,25 @@ class PlotHelpers:
         noise_std=0.01,
         seed=None,
     ):
-        """
-        Create a noisy interpolated version of a function on a local interval around central_value.
+        """Create a noisy interpolated version of a function on a local interval around central_value.
 
-        Parameters
-        ----------
-        function : callable
-            Function to be sampled.
-        central_value : float
-            Central point of the interval.
-        width : float
-            Half-width of the interval.
-        resolution : int
-            Number of sample points.
-        noise_std : float
-            Standard deviation of added Gaussian noise.
-        seed : int, optional
-            Random seed for reproducibility.
+        Args:
+            function : callable
+                Function to be sampled.
+            central_value : float
+                Central point of the interval.
+            width : float
+                Half-width of the interval.
+            resolution : int
+                Number of sample points.
+            noise_std : float
+                Standard deviation of added Gaussian noise.
+            seed : int, optional
+                Random seed for reproducibility.
 
-        Returns
-        -------
-        callable
-            Interpolated noisy function.
+        Returns:
+            callable
+                Interpolated noisy function.
         """
         rng = np.random.default_rng(self.seed if seed is None else seed)
         x_grid = np.linspace(
@@ -210,22 +203,18 @@ class PlotHelpers:
         return noisy_interp
 
     def make_additive_noise_function(self, noise_std=0.01, seed=None):
+        """Add Gaussian noise to the function directly, no interpolation.
+
+        Args:
+            noise_std : float
+                Standard deviation of added noise.
+            seed : int, optional
+                Random seed for reproducibility.
+
+        Returns:
+            callable
+                Noisy function.
         """
-        Add Gaussian noise to the function directly, no interpolation.
-
-        Parameters
-        ----------
-        noise_std : float
-            Standard deviation of added noise.
-        seed : int, optional
-            Random seed for reproducibility.
-
-        Returns
-        -------
-        callable
-            Noisy function.
-        """
-
         rng = np.random.default_rng(self.seed if seed is None else seed)
 
         def noisy_f(x):
@@ -241,31 +230,30 @@ class PlotHelpers:
         y_center=None,
         return_inliers=False,
     ):
-        """
-        Fit a line to (x, y) after removing outliers using a 2.5σ residual filter.
+        """Fit a line to data after removing outliers.
+
+        The removal is done using a 2.5σ residual filter.
         Ensures the central point (central_value, y_center) is always included in the fit.
 
-        Parameters
-        ----------
-        x_vals : array-like
-            X coordinates.
-        y_vals : array-like
-            Y coordinates.
-        central_value : float, optional
-            The central x value to enforce inclusion.
-        y_center : float, optional
-            The corresponding f(central_value) value.
-        return_inliers : bool
-            Whether to return a mask of inlier points.
+        Args:
+            x_vals : array-like
+                X coordinates.
+            y_vals : array-like
+                Y coordinates.
+            central_value : float, optional
+                The central x value to enforce inclusion.
+            y_center : float, optional
+                The corresponding f(central_value) value.
+            return_inliers : bool
+                Whether to return a mask of inlier points.
 
-        Returns
-        -------
-        slope : float
-            Slope of the best-fit line.
-        intercept : float
-            Intercept of the best-fit line.
-        inlier_mask : np.ndarray or None
-            Boolean array indicating which points were kept (if return_inliers=True).
+        Returns:
+            slope : float
+                Slope of the best-fit line.
+            intercept : float
+                Intercept of the best-fit line.
+            inlier_mask : np.ndarray or None
+                Boolean array indicating which points were kept (if return_inliers=True).
         """
         x_vals = np.asarray(x_vals)
         y_vals = np.asarray(y_vals)
@@ -294,20 +282,17 @@ class PlotHelpers:
         return slope, intercept, None
 
     def nd_derivative(self, x, derivative_order):
-        """
-        Compute derivative using numdifftools.
+        """Compute derivative using numdifftools.
 
-        Parameters
-        ----------
-        derivative_order : int
-            Order of the derivative to compute.
-        x : float
-            Point at which to evaluate the derivative.
+        Args:
+            derivative_order : int
+                Order of the derivative to compute.
+            x : float
+                Point at which to evaluate the derivative.
 
-        Returns
-        -------
-        float
-            Derivative estimate from numdifftools.
+        Returns:
+            float
+                Derivative estimate from numdifftools.
         """
         return nd.Derivative(self.function, n=derivative_order)(x)
 
@@ -320,26 +305,23 @@ class PlotHelpers:
         half_width=None,
         num=21,
     ):
-        """
-        Estimate the true derivative via polynomial fitting if no analytical derivative is given.
+        """Estimate the true derivative via polynomial fitting if no analytical derivative is given.
 
-        Parameters
-        ----------
-        x : float, optional
-            Point at which to evaluate (defaults to central_value).
-        degree : int, optional
-            Degree of the fitting polynomial.
-        derivative_order : int, optional
-            Order of the derivative to compute (default is 1).
-        half_width : float, optional
-            Half-width of the fitting interval.
-        num : int, optional
-            Number of points to use in the fit.
+        Args:
+            x : float, optional
+                Point at which to evaluate (defaults to central_value).
+            degree : int, optional
+                Degree of the fitting polynomial.
+            derivative_order : int, optional
+                Order of the derivative to compute (default is 1).
+            half_width : float, optional
+                Half-width of the fitting interval.
+            num : int, optional
+                Number of points to use in the fit.
 
-        Returns
-        -------
-        float
-            Estimated reference derivative.
+        Returns:
+            float
+                Estimated reference derivative.
         """
         if x is None:
             x = self.central_value
@@ -368,24 +350,21 @@ class PlotHelpers:
     def make_shared_noisy_func(
         self, sigma, *, cover_width=None, resolution=401, seed=None
     ):
-        """
-        Generate a shared noisy interpolated function with reproducible randomness.
+        """Generate a shared noisy interpolated function with reproducible randomness.
 
-        Parameters
-        ----------
-        sigma : float
-            Standard deviation of the added noise.
-        cover_width : float, optional
-            Width of the interpolation domain.
-        resolution : int, optional
-            Number of points in interpolation grid.
-        seed : int, optional
-            Random seed to use.
+        Args:
+            sigma : float
+                Standard deviation of the added noise.
+            cover_width : float, optional
+                Width of the interpolation domain.
+            resolution : int, optional
+                Number of points in interpolation grid.
+            seed : int, optional
+                Random seed to use.
 
-        Returns
-        -------
-        callable
-            Noisy interpolated function.
+        Returns:
+            callable
+                Noisy interpolated function.
         """
         base = abs(self.central_value) or 1.0
         width = cover_width or (0.5 * base)
@@ -399,22 +378,19 @@ class PlotHelpers:
         )
 
     def make_less_noisy(self, function, sigma=0.01, seed=42):
-        """
-        Add signal-scaled noise to a function (noise ∝ |f(x)|).
+        """Add signal-scaled noise to a function (noise ∝ |f(x)|).
 
-        Parameters
-        ----------
-        function : callable
-            Base function.
-        sigma : float
-            Noise scaling factor. Default is 0.01.
-        seed : int
-            Seed for the noise RNG. Default is 42.
+        Args:
+            function : callable
+                Base function.
+            sigma : float
+                Noise scaling factor. Default is 0.01.
+            seed : int
+                Seed for the noise RNG. Default is 42.
 
-        Returns
-        -------
-        callable
-            Noisy version of the input function.
+        Returns:
+            callable
+                Noisy version of the input function.
         """
         rng = np.random.default_rng(seed)
 
@@ -428,13 +404,11 @@ class PlotHelpers:
         return noisy
 
     def save_fig(self, filename):
-        """
-        Save the current matplotlib figure to the configured directory.
+        """Save the current matplotlib figure to the configured directory.
 
-        Parameters
-        ----------
-        filename : str
-            File name (with extension) for saving the figure.
+        Args:
+            filename : str
+                File name (with extension) for saving the figure.
         """
         plt.tight_layout()
         plt.savefig(f"{self.plot_dir}/{filename}", dpi=300)

--- a/src/derivkit/plotutils/plot_kit.py
+++ b/src/derivkit/plotutils/plot_kit.py
@@ -1,3 +1,5 @@
+"""Provides an assorted number of styling utilities."""
+
 import os
 import time
 from time import perf_counter
@@ -21,41 +23,18 @@ apply_plot_style()
 
 
 class PlotKit:
-    """
-    A high-level plotting utility for evaluating and comparing numerical derivative methods.
+    """A high-level plotting utility for evaluating and comparing numerical derivative methods.
 
     This class provides multiple plotting routines to assess the accuracy and behavior of
     finite difference and adaptive polynomial fit derivative estimates under noisy conditions.
 
-    Parameters
-    ----------
-    function : callable
-        The target function for which derivatives will be evaluated.
-    central_value : float
-        The point at which the derivative is computed.
-    derivative_order : int, optional
-        The order of the derivative to compute (default is 1).
-    fit_tolerance : float, optional
-        Residual tolerance used in adaptive fitting (default is 0.05).
-    plot_dir : str, optional
-        Directory in which to save generated plots (default is "plots").
-    linewidth : float, optional
-        Line width to use for plots. Uses default style if not specified.
-    colors : dict, optional
-        A dictionary of color overrides keyed by method name (e.g., 'finite', 'adaptive').
-    gradient_colors : dict, optional
-        Optional color map or overrides for gradients or tolerance bands.
-    true_derivative_fn : callable, optional
-        Optional function to compute the true derivative for reference.
-
-    Attributes
-    ----------
-    derivs : DerivativeKit
-        Internal instance used to compute derivatives using both finite and adaptive methods.
-    h : PlotHelpers
-        Helper instance used for diagnostics, noise injection, and figure saving.
-    seed : int
-        Random seed for reproducibility in plots involving noise.
+    Attributes:
+        derivs : DerivativeKit
+            Internal instance used to compute derivatives using both finite and adaptive methods.
+        h : PlotHelpers
+            Helper instance used for diagnostics, noise injection, and figure saving.
+        seed : int
+            Random seed for reproducibility in plots involving noise.
     """
 
     def __init__(
@@ -70,6 +49,28 @@ class PlotKit:
         gradient_colors: Optional[dict] = None,
         true_derivative_fn=None,
     ):
+        """Initialises the class.
+
+        Args:
+            function : callable
+                The target function for which derivatives will be evaluated.
+            central_value : float
+                The point at which the derivative is computed.
+            derivative_order : int, optional
+                The order of the derivative to compute (default is 1).
+            fit_tolerance : float, optional
+                Residual tolerance used in adaptive fitting (default is 0.05).
+            plot_dir : str, optional
+                Directory in which to save generated plots (default is "plots").
+            linewidth : float, optional
+                Line width to use for plots. Uses default style if not specified.
+            colors : dict, optional
+                A dictionary of color overrides keyed by method name (e.g., 'finite', 'adaptive').
+            gradient_colors : dict, optional
+                Optional color map or overrides for gradients or tolerance bands.
+            true_derivative_fn : callable, optional
+                Optional function to compute the true derivative for reference.
+        """
         self.function = function
         self.central_value = central_value
         self.plot_dir = plot_dir
@@ -94,20 +95,17 @@ class PlotKit:
         )
 
     def color(self, key: str) -> str:
-        """
-        Retrieve the color assigned to a specific plot element key.
+        """Retrieve the color assigned to a specific plot element key.
 
-        Parameters
-        ----------
-        key : str
-            Identifier for the color key (e.g., 'finite', 'adaptive', 'central', etc.).
+        Args:
+            key : str
+                Identifier for the color key (e.g., 'finite', 'adaptive', 'central', etc.).
 
-        Returns
-        -------
-        str
-            The hex code or named color string associated with the key.
+        Returns:
+            str
+                The hex code or named color string associated with the key.
 
-        Notes
+        Notes:
         -----
         - Falls back to the default color mapping if the key was not explicitly overridden.
         - Used internally for consistent styling across plots.
@@ -123,35 +121,35 @@ class PlotKit:
         title=None,
         extra_info=None,
     ):
-        """
-        Plot overlaid histograms of derivative estimates from stencil and adaptive methods
-        under repeated noisy evaluations.
+        """Plot overlaid histograms of derivative estimates.
 
-        This method runs multiple trials of noisy function evaluations, computes the derivative
-        using both the finite difference and adaptive fitting methods, and plots their empirical
-        distributions overlaid as histograms.
+        The estimates are determined from stencil and adaptive method under
+        repeated noisy evaluations.
 
-        Parameters
-        ----------
-        derivative_order: int
-            Order of the derivative to compute (e.g., 1 for first derivative).
-        noise_std : float, optional
-            Standard deviation of the Gaussian noise added to the function (default is 0.01).
-        trials : int, optional
-            Number of repeated noisy evaluations to perform (default is 100).
-        bins : int, optional
-            Number of bins to use in the histogram (default is 20).
-        title : str, optional
-            Optional title for the plot.
-        extra_info : str, optional
-            Additional string to append to the saved filename.
+        This method runs multiple trials of noisy function evaluations,
+        computes the derivative using both the finite difference and
+        adaptive fitting methods, and plots their empiricala distributions
+        overlaid as histograms.
 
-        Notes
+        Args:
+            derivative_order: int
+                Order of the derivative to compute (e.g., 1 for first derivative).
+            noise_std : float, optional
+                Standard deviation of the Gaussian noise added to the function (default is 0.01).
+            trials : int, optional
+                Number of repeated noisy evaluations to perform (default is 100).
+            bins : int, optional
+                Number of bins to use in the histogram (default is 20).
+            title : str, optional
+                Optional title for the plot.
+            extra_info : str, optional
+                Additional string to append to the saved filename.
+
+        Notes:
         -----
         - Excludes outliers based on 1st and 99th percentiles to improve plot readability.
         - Displays method-specific variance in the legend for comparison.
         """
-
         plt.figure(figsize=(7.2, 5.2))
         plt.rcParams.update(
             {
@@ -235,34 +233,31 @@ class PlotKit:
         title=None,
         extra_info=None,
     ):
-        """
-        Visualize the adaptive polynomial fit on a noisy function segment.
+        """Visualize the adaptive polynomial fit on a noisy function segment.
 
         This method creates a reproducible noisy realization of the input function
         over a local region around `central_value` and shows which points are used or excluded
         by the adaptive fitting method. It also overlays the fitted polynomial and its
         tolerance band.
 
-        Parameters
-        ----------
-        derivative_order : int
-            The order of the derivative to compute (e.g., 1 for first derivative).
-            Defaults to 1.
-        noise_std : float, optional
-            Standard deviation of the Gaussian noise added to the function (default is 0.01).
-        width : float, optional
-            Width of the interval around `central_value` for generating the noisy segment (default is 0.2).
-        title : str, optional
-            Optional title for the plot.
-        extra_info : str, optional
-            Additional string to append to the saved filename.
+        Args:
+            derivative_order : int
+                The order of the derivative to compute (e.g., 1 for first derivative).
+                Defaults to 1.
+            noise_std : float, optional
+                Standard deviation of the Gaussian noise added to the function (default is 0.01).
+            width : float, optional
+                Width of the interval around `central_value` for generating the noisy segment (default is 0.2).
+            title : str, optional
+                Optional title for the plot.
+            extra_info : str, optional
+                Additional string to append to the saved filename.
 
-        Notes
+        Notes:
         -----
         - Uses a fixed random seed for reproducibility.
         - Highlights the internal logic of the adaptive derivative fitting mechanism visually.
         """
-
         noisy_func = self.h.make_noisy_interpolated_function(
             function=self.function,
             central_value=self.central_value,
@@ -374,34 +369,31 @@ class PlotKit:
         title=None,
         extra_info=None,
     ):
-        """
-        Plot mean squared error (MSE) of derivative estimates vs. noise level.
+        """Plot mean squared error (MSE) of derivative estimates vs. noise level.
 
         This method evaluates both finite difference and adaptive derivative estimators
         across a range of Gaussian noise standard deviations. It plots:
         - MSE vs. noise level (log scale)
         - Relative difference between adaptive and finite MSEs
 
-        Parameters
-        ----------
-        derivative_order : int
-            The order of the derivative to compute (e.g., 1 for first derivative).
-        noise_levels : array-like
-            List or array of noise standard deviation values to test.
-        trials : int, optional
-            Number of Monte Carlo trials per noise level (default is 50).
-        title : str, optional
-            Optional title for the plot.
-        extra_info : str, optional
-            Additional string to append to the saved filename.
+        Args:
+            derivative_order : int
+                The order of the derivative to compute (e.g., 1 for first derivative).
+            noise_levels : array-like
+                List or array of noise standard deviation values to test.
+            trials : int, optional
+                Number of Monte Carlo trials per noise level (default is 50).
+            title : str, optional
+                Optional title for the plot.
+            extra_info : str, optional
+                Additional string to append to the saved filename.
 
-        Notes
+        Notes:
         -----
         - Finite difference uses a fixed step size relative to `central_value`.
         - Adaptive fit uses polynomial regression with tolerance-controlled filtering.
         - Useful for comparing robustness of methods under varying noise.
         """
-
         true_val = self.h.reference_derivative(self.central_value)
         rng = np.random.default_rng(42)  # master seed for this figure
 
@@ -500,30 +492,27 @@ class PlotKit:
     def plot_ecdf_errors(
         self, noise_std=0.01, trials=200, title=None, extra_info=None
     ):
-        """
-        Plot empirical cumulative distribution functions (ECDFs) of squared errors.
+        """Plot empirical cumulative distribution functions (ECDFs) of squared errors.
 
         This method compares the distribution of squared errors from finite difference and
         adaptive derivative estimators by plotting their ECDFs under repeated noisy evaluations.
 
-        Parameters
-        ----------
-        noise_std : float, optional
-            Standard deviation of the Gaussian noise added to the function (default is 0.01).
-        trials : int, optional
-            Number of Monte Carlo trials to generate error samples (default is 200).
-        title : str, optional
-            Optional title for the plot.
-        extra_info : str, optional
-            Additional string to append to the saved filename.
+        Args:
+            noise_std : float, optional
+                Standard deviation of the Gaussian noise added to the function (default is 0.01).
+            trials : int, optional
+                Number of Monte Carlo trials to generate error samples (default is 200).
+            title : str, optional
+                Optional title for the plot.
+            extra_info : str, optional
+                Additional string to append to the saved filename.
 
-        Notes
+        Notes:
         -----
         - ECDF provides a full view of the error distribution, not just summary statistics.
         - The reference derivative value is used to compute true squared error per trial.
         - Useful for visualizing which method tends to produce smaller errors more often.
         """
-
         true_val = self.h.reference_derivative(self.central_value)
         rng = np.random.default_rng(123)
 
@@ -581,8 +570,7 @@ class PlotKit:
     def plot_paired_error_differences(
         self, noise_std=0.01, trials=200, title=None, extra_info=None
     ):
-        """
-        Plot paired squared error differences between adaptive and finite methods.
+        """Plot paired squared error differences between adaptive and finite methods.
 
         This method runs repeated noisy derivative trials and computes the squared error
         for both adaptive and finite difference methods. It then plots the pairwise
@@ -593,24 +581,22 @@ class PlotKit:
         - Finite better (Δ > 0)
         - Tie (Δ = 0)
 
-        Parameters
-        ----------
-        noise_std : float, optional
-            Standard deviation of the Gaussian noise added to the function (default is 0.01).
-        trials : int, optional
-            Number of paired Monte Carlo trials to run (default is 200).
-        title : str, optional
-            Optional title for the plot.
-        extra_info : str, optional
-            Additional string to append to the saved filename.
+        Args:
+            noise_std : float, optional
+                Standard deviation of the Gaussian noise added to the function (default is 0.01).
+            trials : int, optional
+                Number of paired Monte Carlo trials to run (default is 200).
+            title : str, optional
+                Optional title for the plot.
+            extra_info : str, optional
+                Additional string to append to the saved filename.
 
-        Notes
+        Notes:
         -----
         - A horizontal line at Δ = 0 indicates equal performance.
         - The estimated win rate (P(Δ < 0)) is shown in the legend.
         - This visualization provides intuitive insight into method-wise reliability.
         """
-
         true_val = self.h.reference_derivative(self.central_value)
         rng = np.random.default_rng(123)
 
@@ -720,38 +706,38 @@ def plot_multi_order_error_vs_noise(
     extra_info=None,
     plot_dir="plots",
 ):
-    """
-    Plot mean squared error (MSE) versus inverse signal-to-noise ratio (1/SNR)
-    for multiple derivative orders and estimation methods.
+    """Plot mean squared error versus inverse signal-to-noise ratio.
+
+    The mean squared error (MSE) and inverse signal-to-noise ratio (SNR) are
+    determined for multiple derivative orders and estimation methods.
 
     The function injects Gaussian noise into the target function, scaled inversely
     with SNR and proportionally to |f(x)|. It compares the performance of finite
     difference and adaptive polynomial fitting methods.
 
-    Parameters
-    ----------
-    function : callable
-        Target function to differentiate.
-    central_value : float
-        Point at which the derivative is computed.
-    snr_values : array-like, optional
-        List or array of SNR values (default is log-spaced from 10 to 1e5).
-    orders : tuple of int, optional
-        Derivative orders to evaluate (default: (1, 2, 3)).
-    trials : int, optional
-        Number of Monte Carlo trials per SNR and order (default: 50).
-    fit_tolerance : float or dict, optional
-        Residual tolerance used in adaptive fitting. Can be a float or a dict keyed by order.
-    clip_threshold : float, optional
-        Maximum allowed squared error; larger values are clipped to prevent skew (default: 1e6).
-    title : str, optional
-        Title for the plot.
-    extra_info : str, optional
-        Additional string to append to the saved filename.
-    plot_dir : str, optional
-        Directory in which to save generated plots (default is "plots").
+    Args:
+        function : callable
+            Target function to differentiate.
+        central_value : float
+            Point at which the derivative is computed.
+        snr_values : array-like, optional
+            List or array of SNR values (default is log-spaced from 10 to 1e5).
+        orders : tuple of int, optional
+            Derivative orders to evaluate (default: (1, 2, 3)).
+        trials : int, optional
+            Number of Monte Carlo trials per SNR and order (default: 50).
+        fit_tolerance : float or dict, optional
+            Residual tolerance used in adaptive fitting. Can be a float or a dict keyed by order.
+        clip_threshold : float, optional
+            Maximum allowed squared error; larger values are clipped to prevent skew (default: 1e6).
+        title : str, optional
+            Title for the plot.
+        extra_info : str, optional
+            Additional string to append to the saved filename.
+        plot_dir : str, optional
+            Directory in which to save generated plots (default is "plots").
 
-    Notes
+    Notes:
     -----
     - Uses a fixed random seed for reproducibility.
     - Derivatives are computed using both finite differences and adaptive polynomial fitting.
@@ -875,27 +861,23 @@ def plot_multi_order_error_vs_noise(
 
 
 def slow_function(x, sleep_time):
-    """
-    Simulates a slow, compute-intensive mathematical function.
+    """Simulates a slow, compute-intensive mathematical function.
 
     This function applies a non-linear transformation to the input `x` involving
     sine, exponential decay, and logarithmic growth, repeated 100 times to mimic
     computational load. Additionally, it pauses execution for a specified duration
     using `time.sleep`.
 
-    Parameters
-    ----------
-    x : float or np.ndarray
-        Input value(s) to be processed.
-    sleep_time : float
-        Time in seconds to pause execution before starting computation.
+    Args:
+        x : float or np.ndarray
+            Input value(s) to be processed.
+        sleep_time : float
+            Time in seconds to pause execution before starting computation.
 
-    Returns
-    -------
-    float or np.ndarray
-        Transformed value(s) after applying the repeated operation.
+    Returns:
+        float or np.ndarray
+            Transformed value(s) after applying the repeated operation.
     """
-
     time.sleep(sleep_time)
     for _ in range(100):
         x = np.sin(x**2) * np.exp(-(x**2)) + np.log(1 + x**2)
@@ -903,29 +885,26 @@ def slow_function(x, sleep_time):
 
 
 def make_slow_func(sleep_time):
+    """Creates a lambda function that wraps `slow_function` with a fixed sleep time.
+
+    Args:
+        sleep_time : float
+            Time in seconds that the wrapped function will sleep before computation.
+
+    Returns:
+        function
+            A lambda function that takes `x` as input and calls `slow_function(x, sleep_time)`.
     """
-    Creates a lambda function that wraps `slow_function` with a fixed sleep time.
-
-    Parameters
-    ----------
-    sleep_time : float
-        Time in seconds that the wrapped function will sleep before computation.
-
-    Returns
-    -------
-    function
-        A lambda function that takes `x` as input and calls `slow_function(x, sleep_time)`.
-    """
-
     return lambda x: slow_function(x, sleep_time)
 
 
 def plot_timing_for_order(
     order, sleep_times, timings_adaptive, timings_finite
 ):
-    """
-    Plot timing benchmarks comparing adaptive and finite difference methods
-    for a given derivative order as a function of simulated function evaluation time.
+    """Plot timing benchmarks comparing adaptive and finite difference methods.
+
+    The comparison is plotted for a given derivative order as a function of
+    simulated function evaluation time.
 
     This function assumes access to global dictionaries `timings_adaptive` and
     `timings_finite`, which store timing results for various derivative orders,
@@ -934,21 +913,15 @@ def plot_timing_for_order(
     factor of the adaptive method relative to finite differences, and visualizes
     the timing comparison.
 
-    Parameters
-    ----------
-    order : int
-        The derivative order for which to generate the timing comparison plot.
-    sleep_times : list of float
-        List of simulated function evaluation times (in seconds) used for the x-axis.
-    timings_adaptive : dict
-        Dictionary containing timing results for the adaptive method, keyed by derivative order.
-    timings_finite : dict
-        Dictionary containing timing results for the finite difference method, keyed by derivative order.
-
-    Returns
-    -------
-    None
-        Displays a matplotlib plot and prints the slowdown factor in the legend.
+    Args:
+        order : int
+            The derivative order for which to generate the timing comparison plot.
+        sleep_times : list of float
+            List of simulated function evaluation times (in seconds) used for the x-axis.
+        timings_adaptive : dict
+            Dictionary containing timing results for the adaptive method, keyed by derivative order.
+        timings_finite : dict
+            Dictionary containing timing results for the finite difference method, keyed by derivative order.
     """
     x = np.array(sleep_times)
     y_adaptive = np.array(timings_adaptive[order])
@@ -996,9 +969,10 @@ def plot_timing_for_order(
 def benchmark_derivative_timing_vs_order(
     function, central_value, orders, stencil_points=5, stencil_stepsize=0.01
 ):
-    """
-    Benchmark and plot the evaluation time of adaptive vs. finite difference
-    derivative estimation methods across multiple derivative orders.
+    """Benchmark and plot the evaluation time of adaptive vs. finite differences.
+
+    The benchmarking is done for derivative estimation methods across multiple
+    derivative orders.
 
     This function measures and compares the runtime of the `DerivativeKit`'s
     adaptive and finite difference methods for computing derivatives of the
@@ -1006,23 +980,17 @@ def benchmark_derivative_timing_vs_order(
     It generates a plot showing how the evaluation time scales with derivative order
     and the relative slowdown of adaptive vs. finite difference.
 
-    Parameters
-    ----------
-    function : callable
-        The function to differentiate.
-    central_value : float
-        The point at which the derivative is evaluated.
-    orders : list of int
-        The derivative orders to benchmark.
-    stencil_points: int, optional
-        Number of stencil points to use for the finite difference method (default is 5).
-    stencil_stepsize: float, optional
-        Step size for the finite difference stencil (default is 0.01).
-
-    Returns
-    -------
-    None
-        Displays a matplotlib plot comparing timing for each method and their ratio.
+    Args:
+        function : callable
+            The function to differentiate.
+        central_value : float
+            The point at which the derivative is evaluated.
+        orders : list of int
+            The derivative orders to benchmark.
+        stencil_points: int, optional
+            Number of stencil points to use for the finite difference method (default is 5).
+        stencil_stepsize: float, optional
+            Step size for the finite difference stencil (default is 0.01).
     """
     adaptive_times = []
     finite_times = []
@@ -1119,38 +1087,33 @@ def plot_adaptive_timing_sweeps(
     output_filename=None,
     n_workers=1,
 ):
-    """
-    Benchmark and plot timing results for adaptive derivative estimation as a function of:
+    """Benchmark and plot timing results for adaptive derivative estimation.
+
+    The benchmarking is done as a function of:
     (1) `min_used_points` with fixed `fit_tolerance`
     (2) `fit_tolerance` with fixed `min_used_points`
 
-    Parameters
-    ----------
-    sleep_time : float
-        Artificial delay in function evaluation.
-    central_value : float
-        Point at which to evaluate the derivative.
-    deriv_orders : tuple of int
-        Derivative orders to benchmark and plot.
-    fit_tolerance_fixed : float
-        The fixed fit tolerance used when sweeping `min_used_points`.
-    min_used_points_fixed : int
-        The fixed number of points used when sweeping `fit_tolerance`.
-    min_pts_list : array-like, optional
-        Values of `min_used_points` to sweep. Default: np.arange(5, 30, 2).
-    fit_tolerances : array-like, optional
-        Values of `fit_tolerance` to sweep. Default: np.logspace(-4, log10(0.2), 14).
-    save_fig : bool
-        If True, saves the figure to 'plots/adaptive_timing_sweeps.{png,pdf}'.
-    output_filename : str or None
-        If provided, also saves the benchmark results to a `.npz` file.
-    n_workers: int, optional
-            Number of worker to use in multiprocessing. Default is 1 (no multiprocessing).
-
-    Returns
-    -------
-    None
-        Displays the plot. Optionally saves results and/or figure.
+    Args:
+        sleep_time : float
+            Artificial delay in function evaluation.
+        central_value : float
+            Point at which to evaluate the derivative.
+        deriv_orders : tuple of int
+            Derivative orders to benchmark and plot.
+        fit_tolerance_fixed : float
+            The fixed fit tolerance used when sweeping `min_used_points`.
+        min_used_points_fixed : int
+            The fixed number of points used when sweeping `fit_tolerance`.
+        min_pts_list : array-like, optional
+            Values of `min_used_points` to sweep. Default: np.arange(5, 30, 2).
+        fit_tolerances : array-like, optional
+            Values of `fit_tolerance` to sweep. Default: np.logspace(-4, log10(0.2), 14).
+        save_fig : bool
+            If True, saves the figure to 'plots/adaptive_timing_sweeps.{png,pdf}'.
+        output_filename : str or None
+            If provided, also saves the benchmark results to a `.npz` file.
+        n_workers: int, optional
+                Number of worker to use in multiprocessing. Default is 1 (no multiprocessing).
     """
     # === Run benchmark
     if min_pts_list is None:
@@ -1266,34 +1229,32 @@ def plot_function_with_residuals(
     save_fig=True,
     function_name=None,
 ):
-    """
-    Visualize a function and its tangent approximations with residual diagnostics.
+    """Visualize a function and its tangent approximations with residual diagnostics.
 
     This function plots the input function alongside its finite difference and adaptive
     tangent approximations at a given point. It includes diagnostics such as residuals,
     fractional residuals, and optionally the ratio of fractional residuals (adaptive / finite),
     helping to assess the accuracy and behavior of each method.
 
-    Parameters
-    ----------
-    function : callable
-        The target function to differentiate.
-    central_value : float
-        The point x₀ at which the derivative is computed and tangents are anchored.
-    derivative_order : int, optional
-        The order of the derivative to estimate (default is 1).
-    dx : float, optional
-        Half-width of the plotting interval around `central_value` (default is 0.5).
-    title : str, optional
-        Title to display at the top of the figure (default is descriptive).
-    show_ratio_panel : bool, optional
-        If True, adds a fourth panel showing the ratio of fractional residuals (default is True).
-    save_fig : bool, optional
-        If True, saves the resulting plot to 'plots/' directory as PDF and PNG (default is True).
-    function_name : str, optional
-        Name of the function used in saved filenames (default is None).
+    Args:
+        function : callable
+            The target function to differentiate.
+        central_value : float
+            The point x₀ at which the derivative is computed and tangents are anchored.
+        derivative_order : int, optional
+            The order of the derivative to estimate (default is 1).
+        dx : float, optional
+            Half-width of the plotting interval around `central_value` (default is 0.5).
+        title : str, optional
+            Title to display at the top of the figure (default is descriptive).
+        show_ratio_panel : bool, optional
+            If True, adds a fourth panel showing the ratio of fractional residuals (default is True).
+        save_fig : bool, optional
+            If True, saves the resulting plot to 'plots/' directory as PDF and PNG (default is True).
+        function_name : str, optional
+            Name of the function used in saved filenames (default is None).
 
-    Notes
+    Notes:
     -----
     - Uses `DerivativeKit` to estimate derivatives via both adaptive fitting and finite differences.
     - Residuals are defined as: f(x) − T(x), where T(x) is the tangent.

--- a/src/derivkit/plotutils/plot_style.py
+++ b/src/derivkit/plotutils/plot_style.py
@@ -1,3 +1,5 @@
+"""Defines variables useful for visually nice plots."""
+
 import matplotlib as mpl
 
 DEFAULT_LINEWIDTH = 2.0
@@ -26,6 +28,7 @@ LIGHT_GRAY = "#E0E0E0"
 
 
 def apply_plot_style():
+    """Applies style."""
     mpl.rcParams.update(
         {
             "text.usetex": False,

--- a/src/derivkit/utils.py
+++ b/src/derivkit/utils.py
@@ -1,9 +1,10 @@
+"""Provides assorted utility functions."""
+
 import numpy as np
 
 
 def log_debug_message(message, debug=False, log_file=None, log_to_file=None):
-    """
-    Logs a debug message to stdout and optionally to a file.
+    """Logs a debug message to stdout and optionally to a file.
 
     Args:
         message (str): The debug message to print/log.
@@ -25,8 +26,7 @@ def log_debug_message(message, debug=False, log_file=None, log_to_file=None):
 
 
 def is_finite_and_differentiable(function, x, delta=1e-5, tol=1e-2):
-    """
-    Checks if a function is finite and numerically differentiable at a point.
+    """Checks if a function is finite and numerically differentiable at a point.
 
     Args:
         function (callable): The function to test.
@@ -35,7 +35,8 @@ def is_finite_and_differentiable(function, x, delta=1e-5, tol=1e-2):
         tol (float): Tolerance for differentiability check.
 
     Returns:
-        bool: True if function is finite and differentiable at x, False otherwise.
+        bool: True if function is finite and differentiable at x, False
+            otherwise.
     """
     try:
         f0 = np.asarray(function(x))
@@ -61,8 +62,7 @@ def is_finite_and_differentiable(function, x, delta=1e-5, tol=1e-2):
 
 
 def normalize_derivative(derivative, reference):
-    """
-    Computes the relative error between estimated and reference derivative.
+    """Computes the relative error between estimated and reference derivative.
 
     Args:
         derivative (float or np.ndarray): Estimated derivative.
@@ -75,8 +75,7 @@ def normalize_derivative(derivative, reference):
 
 
 def central_difference_error_estimate(step_size, order=1):
-    """
-    Provides a rough truncation error estimate for central differences.
+    """Provides a rough truncation error estimate for central differences.
 
     Args:
         step_size (float): Finite difference step size.
@@ -98,11 +97,10 @@ def central_difference_error_estimate(step_size, order=1):
 
 
 def is_symmetric_grid(x_vals):
-    """
-    Checks if evaluation grid is symmetric around 0.
+    """Checks if evaluation grid is symmetric around 0.
 
     Args:
-        x_vals (np.ndarray): Evaluation points (1D).
+        x_vals (:class:`np.ndarray`): Evaluation points (1D).
 
     Returns:
         bool: True if grid is symmetric, False otherwise.
@@ -116,8 +114,7 @@ def is_symmetric_grid(x_vals):
 
 
 def generate_test_function(name="sin"):
-    """
-    Returns a known test function and its first/second derivatives.
+    """Returns a known test function and its first/second derivatives.
 
     Args:
         name (str): One of 'sin', 'exp', 'polynomial', 'gaussian'.


### PR DESCRIPTION
The module docstrings are written using various different conventions. As a result, the documentation pages aren't always properly rendered. I propose we rewrite the docstrings using the Google docstring standard:

            https://google.github.io/styleguide/pyguide.html#docstrings

This makes use of the Napoleon module, which I had added previously. See https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html for more details.

In the case of the plotutils files I have only made the necessary changes so that ruff doesn't complain. The reason for this being that I think we discussed that these functions are mostly for our own convenience and that general users aren't expected to import them.

I needed to make some changes to the wording of the docstrings so please check if I reworded something in a way that does not accurately reflect the objects.
