### PR TITLE
Update supported python versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
3.9 is nearing end of life, while 3.13 is near the end of its bugfix phase. See https://devguide.python.org/versions/#status-of-python-versions