### PR TITLE
Add `derivative_kit` and `likelihood_expension` to list of submodules

### DIFF
--- a/docs/derivkit.rst
+++ b/docs/derivkit.rst
@@ -8,9 +8,10 @@ Submodules
    :maxdepth: 4
 
    derivkit.adaptive_fit
+   derivkit.derivative_kit
    derivkit.finite_difference
    derivkit.forecast_kit
-   derivkit.kit
+   derivkit.likelihood_expansion
    derivkit.utils
 
 Module contents


### PR DESCRIPTION
FIxes #52, undoes #53.